### PR TITLE
Add Supabase keep-alive scheduled workflow

### DIFF
--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -1,0 +1,28 @@
+name: Supabase Keep Alive
+
+on:
+  schedule:
+    # 月曜と木曜の 0:00 UTC に実行（週2回）
+    - cron: '0 0 * * 1,4'
+  workflow_dispatch: # 手動実行も可能
+
+jobs:
+  ping:
+    name: Ping Supabase
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase REST API
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${{ secrets.SUPABASE_URL }}/rest/v1/" \
+            -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}")
+
+          echo "Supabase response status: $STATUS"
+
+          if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 300 ]; then
+            echo "Supabase is alive."
+          else
+            echo "Unexpected status code: $STATUS"
+            exit 1
+          fi

--- a/.github/workflows/supabase-keep-alive.yml
+++ b/.github/workflows/supabase-keep-alive.yml
@@ -6,17 +6,25 @@ on:
     - cron: '0 0 * * 1,4'
   workflow_dispatch: # 手動実行も可能
 
+permissions: {}
+
 jobs:
   ping:
     name: Ping Supabase
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - name: Ping Supabase REST API
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          STATUS=$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-delay 5 --retry-all-errors \
             "${{ secrets.SUPABASE_URL }}/rest/v1/" \
             -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}")
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_ANON_KEY }}") || {
+            echo "Failed to reach Supabase endpoint"
+            exit 1
+          }
 
           echo "Supabase response status: $STATUS"
 


### PR DESCRIPTION
## 🔗 起因 Issue（全ブランチ共通・必須）

<!-- Issue番号が不明なため、コメント欄で確認が必要です -->

---

## 🧩 修正・追加の概要

### 🧱 機能追加（feature ブランチの場合）

**目的・背景（なぜ必要か）**
- Supabase の無料プランでは、一定期間アクティビティがないとプロジェクトが休止状態になる可能性があります
- 定期的に REST API にアクセスすることで、プロジェクトを常にアクティブな状態に保つ必要があります

**実装概要**
- GitHub Actions のスケジュール実行機能を使用して、毎週月曜日と木曜日の UTC 0:00 に Supabase REST API に対して ping リクエストを送信
- HTTP ステータスコードが 2xx の場合は成功、それ以外の場合はエラーとして終了
- 手動実行（`workflow_dispatch`）にも対応し、必要に応じて即座にテスト実行可能

**影響範囲**
- CI/CD パイプライン（`.github/workflows/`）
- Supabase プロジェクトの稼働状態維持

---

## ✅ チェックリスト（全ブランチ共通）

- [ ] 起因 Issue に紐づいている（または理由をコメント済み）
- [x] ローカルで動作確認済み（ワークフロー構文の妥当性確認）
- [x] 関連テストを追加／更新済み（N/A - 設定ファイル）
- [x] Linter / Formatter チェックを通過
- [x] 不要なログやコメントを削除
- [x] モノレポ全体への影響を確認済み（GitHub Actions のみ）

---

## 🧪 動作確認方法

- ワークフロー構文の妥当性確認済み
- `workflow_dispatch` トリガーで手動実行可能
- 初回実行は月曜日または木曜日の UTC 0:00 に自動実行予定

---

## 🗒 補足事項（任意）

- Supabase の認証情報（`SUPABASE_URL`、`SUPABASE_ANON_KEY`）は GitHub Secrets に登録済みであることを前提としています
- 週 2 回の実行頻度は、Supabase の休止ポリシーに基づいて設定しています（必要に応じて調整可能）

https://claude.ai/code/session_015fAQTygSqtcgtCwNArSjCF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * バックエンド接続の稼働監視を自動化するワークフローを追加しました。定期実行（週2回、UTC月曜・木曜 00:00）と手動トリガーに対応し、エンドポイントへ定期的にリクエストを送りHTTPステータスを確認します。2xx以外や通信失敗はエラー扱いでワークフローを失敗させ、リトライやタイムアウト制御、明確な失敗メッセージを備えています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->